### PR TITLE
Add type restriction to required

### DIFF
--- a/src/render.cr
+++ b/src/render.cr
@@ -93,7 +93,7 @@ module JSONSchema
       end
 
       unless @required.nil?
-        options["required"] = @required.to_s
+        options["required"] = @required.to_s + " of String"
       end
 
       unless @property_names.nil?


### PR DESCRIPTION
When the required property is output, as part of reading in the schema using the `JSONSchema#create_validator` macro, he required property is missing a type restriction on the array. This does not compile on recent versions of Crystal, as where the array is empty, the compiler cannot deduce its type. This patch appends the type to the array, to ensure that when it is empty, the compiler can still deduce the type.